### PR TITLE
Flash match

### DIFF
--- a/order_router/src/main.sw
+++ b/order_router/src/main.sw
@@ -116,7 +116,8 @@ impl OrderRouter for Contract {
             INVALID_MATCH,
         );
 
-        let (taker_filled, maker_filled) = abi(OneDeltaOrders, ONE_DELTA_ORDERS_CONTRACT_ID.bits()).fill(
+        let orders = abi(OneDeltaOrders, ONE_DELTA_ORDERS_CONTRACT_ID.into());
+        let (taker_filled, maker_filled) = orders.fill(
             order,
             signature,
             maker_amount,

--- a/order_router/src/main.sw
+++ b/order_router/src/main.sw
@@ -16,7 +16,7 @@ use std::{
 };
 use sway_libs::reentrancy::reentrancy_guard;
 use order_utils::{
-    compute_order_hash,
+    compute_taker_fill_amount,
     get_expiry,
     IFlashCallback,
     is_contract_receiver,
@@ -45,11 +45,10 @@ abi OrderRouter {
         taker_fill_amount: u64,
         taker_receiver: Identity,
         data: Option<Bytes>,
-    ) -> (u64, u64);
+    );
 
     #[storage(read, write)]
     fn flash(
-        sender: Identity,
         maker_asset: b256,
         taker_asset: b256,
         maker_amount: u64,
@@ -65,8 +64,8 @@ configurable {
 storage {}
 
 // error codes
-const NO_ERROR = 0u64;
 const INVALID_SENDER = 101u64;
+const INVALID_MATCH = 102u64;
 
 impl OrderRouter for Contract {
     #[storage(write, read), payable]
@@ -76,19 +75,24 @@ impl OrderRouter for Contract {
         taker_fill_amount: u64,
         taker_receiver: Identity,
         data: Option<Bytes>,
-    ) -> (u64, u64) {
-        abi(OneDeltaOrders, ONE_DELTA_ORDERS_CONTRACT_ID.bits()).fill(
+    ) {
+        let orders = abi(OneDeltaOrders, ONE_DELTA_ORDERS_CONTRACT_ID.into());
+        orders.fill(
             order,
             order_signature,
             taker_fill_amount,
             taker_receiver,
             data,
-        )
+        );
+        let asset_id = AssetId::from(order.taker_asset);
+        let profit = this_balance(asset_id);
+        if profit != 0 {
+            transfer(msg_sender().unwrap(), asset_id, this_balance(asset_id));
+        }
     }
 
     #[storage(read, write)]
     fn flash(
-        sender: Identity,
         maker_asset: b256,
         taker_asset: b256,
         maker_amount: u64,
@@ -104,12 +108,26 @@ impl OrderRouter for Contract {
         );
 
         let (order, signature) = to_order_and_sig(data);
-        abi(OneDeltaOrders, ONE_DELTA_ORDERS_CONTRACT_ID.bits()).fill(
+        require(
+            msg_sender()
+                .unwrap()
+                .bits() == ONE_DELTA_ORDERS_CONTRACT_ID
+                .bits(),
+            INVALID_MATCH,
+        );
+
+        let (taker_filled, maker_filled) = abi(OneDeltaOrders, ONE_DELTA_ORDERS_CONTRACT_ID.bits()).fill(
             order,
             signature,
             maker_amount,
-            Identity::ContractId(ONE_DELTA_ORDERS_CONTRACT_ID),
+            Identity::ContractId(ContractId::this()),
             None,
+        );
+
+        transfer(
+            Identity::ContractId(ContractId::from(ONE_DELTA_ORDERS_CONTRACT_ID)),
+            AssetId::from(taker_asset),
+            taker_amount,
         );
     }
 }

--- a/order_utils/src/main.sw
+++ b/order_utils/src/main.sw
@@ -20,7 +20,6 @@ use std::{
 abi IFlashCallback {
     #[storage(read, write)]
     fn flash(
-        sender: Identity,
         maker_asset: b256,
         taker_asset: b256,
         maker_amount: u64,

--- a/test/fill.test.ts
+++ b/test/fill.test.ts
@@ -5,7 +5,6 @@ import { OrderInput } from '../ts-scripts/typegen/OneDeltaOrders';
 import { OrderTestUtils } from './utils';
 import { ZeroBytes32 } from 'fuels';
 
-
 describe('Order fill via `msg_amount`', async () => {
 
   test('If attempt to fill more than taker_amount, do not error', async () => {
@@ -198,11 +197,17 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -216,9 +221,8 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       total_maker_asset_balance_before,
-      total_taker_asset_balance_before
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -236,11 +240,17 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -253,9 +263,8 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       total_maker_asset_balance_after,
-      total_taker_asset_balance_after
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -276,11 +285,6 @@ describe('Order fill via `msg_amount`', async () => {
       total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toString()
     ).to.equal(
       maker_amount.toString()
-    )
-    expect(
-      total_taker_asset_balance_after.sub(total_taker_asset_balance_before).toString()
-    ).to.equal(
-      taker_amount.toString()
     )
 
     // validate taker change
@@ -357,14 +361,19 @@ describe('Order fill via `msg_amount`', async () => {
     })
     const signatureRaw = await maker.signMessage(OrderTestUtils.packOrder(order, Orders))
 
-
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -377,11 +386,11 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       total_maker_asset_balance_before,
-      total_taker_asset_balance_before
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
+
 
     const taker_fill_amount = OrderTestUtils.getRandomAmount(1, Number(taker_amount.toString()))
 
@@ -401,11 +410,17 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -418,9 +433,8 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       total_maker_asset_balance_after,
-      total_taker_asset_balance_after
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -441,11 +455,6 @@ describe('Order fill via `msg_amount`', async () => {
       total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toString()
     ).to.equal(
       maker_fill_amount.toString()
-    )
-    expect(
-      total_taker_asset_balance_after.sub(total_taker_asset_balance_before).toString()
-    ).to.equal(
-      taker_fill_amount.toString()
     )
 
     // validate taker change
@@ -500,15 +509,20 @@ describe('Order fill via `msg_amount`', async () => {
       maker_receiver: ZeroBytes32
     })
     const signatureRaw = await maker.signMessage(OrderTestUtils.packOrder(order, Orders))
-
-
+    
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -521,9 +535,8 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       total_maker_asset_balance_before,
-      total_taker_asset_balance_before
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -562,11 +575,17 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -579,9 +598,8 @@ describe('Order fill via `msg_amount`', async () => {
 
     const [
       total_maker_asset_balance_after,
-      total_taker_asset_balance_after
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -602,11 +620,6 @@ describe('Order fill via `msg_amount`', async () => {
       total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toString()
     ).to.equal(
       maker_fill_amount.toString()
-    )
-    expect(
-      total_taker_asset_balance_after.sub(total_taker_asset_balance_before).toString()
-    ).to.equal(
-      taker_amount.toString()
     )
 
     // validate taker change
@@ -660,15 +673,20 @@ describe('Order fill via `msg_amount`', async () => {
       maker_receiver: ZeroBytes32
     })
     const signatureRaw = await maker.signMessage(OrderTestUtils.packOrder(order, Orders))
-
-
+   
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -677,6 +695,14 @@ describe('Order fill via `msg_amount`', async () => {
     ] = await OrderTestUtils.getConventionalBalances(
       taker,
       [maker_asset, taker_asset]
+    )
+
+
+    const [
+      total_maker_asset_balance_before,
+    ] = await OrderTestUtils.getTotalBalances(
+      [maker_asset],
+      Orders
     )
 
     const maker_fill_amount = OrderTestUtils.getRandomAmount(1, Number(maker_amount.toString()))
@@ -692,22 +718,38 @@ describe('Order fill via `msg_amount`', async () => {
       .callParams({ forward: { assetId: taker_asset, amount: taker_fill_amount } })
       .call()
 
-    const [
-      maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
-    ] = await OrderTestUtils.getMakerBalances(
-      maker.address.toB256(),
-      [maker_asset, taker_asset],
-      Orders
-    )
+      await OrderTestUtils.testFillStatus(order, Orders, taker_fill_amount, false)
 
-    const [
-      taker_maker_asset_balance_after,
-      taker_taker_asset_balance_after
-    ] = await OrderTestUtils.getConventionalBalances(
-      taker,
-      [maker_asset, taker_asset]
-    )
+      const [
+        maker_maker_asset_balance_after,
+      ] = await OrderTestUtils.getMakerBalances(
+        maker.address.toB256(),
+        [maker_asset],
+        Orders
+      )
+  
+      const [
+        maker_taker_asset_balance_after
+      ] = await OrderTestUtils.getConventionalBalances(
+        maker,
+        [taker_asset],
+      )
+  
+      const [
+        taker_maker_asset_balance_after,
+        taker_taker_asset_balance_after
+      ] = await OrderTestUtils.getConventionalBalances(
+        taker,
+        [maker_asset, taker_asset]
+      )
+  
+      const [
+        total_maker_asset_balance_after,
+      ] = await OrderTestUtils.getTotalBalances(
+        [maker_asset],
+        Orders
+      )
+  
 
     const expected_roundingError = Math.ceil(maker_amount.toNumber() / taker_amount.toNumber())
 
@@ -725,6 +767,13 @@ describe('Order fill via `msg_amount`', async () => {
       taker_fill_amount.toString()
     )
 
+    // validate total balances
+    expect(
+      total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toNumber()
+    ).to.approximately(
+      maker_fill_amount.toNumber(),
+      expected_roundingError
+    )
     // validate taker change
     expect(
       taker_maker_asset_balance_after.sub(taker_maker_asset_balance_before).toNumber()

--- a/test/fillCustomReceiver.test.ts
+++ b/test/fillCustomReceiver.test.ts
@@ -9,7 +9,6 @@ import { txParams } from '../ts-scripts/utils/constants';
 
 describe('Order fill with custom maker_receiver', async () => {
 
-
   test('Facilitates full order fill to custom receiver', async () => {
 
     const launched = await launchTestNode({ walletsConfig: { count: 3 } });

--- a/test/fillFundedExactIn.test.ts
+++ b/test/fillFundedExactIn.test.ts
@@ -116,22 +116,19 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
       .callParams({ forward: { assetId: maker_asset, amount: maker_amount } })
       .call()
 
-
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
     const [
-      total_maker_asset_balance_before,
-      total_taker_asset_balance_before
-    ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
-      Orders
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -140,6 +137,13 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
     ] = await OrderTestUtils.getConventionalBalances(
       taker,
       [maker_asset, taker_asset]
+    )
+
+    const [
+      total_maker_asset_balance_before,
+    ] = await OrderTestUtils.getTotalBalances(
+      [maker_asset],
+      Orders
     )
 
     /** DEFINE PARAMETERS */
@@ -188,13 +192,21 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
     const tx = await taker.sendTransaction(finalRequest, { estimateTxDependencies: true })
     await tx.waitForResult()
 
+    await OrderTestUtils.testFillStatus(order, Orders, taker_amount, false)
+
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -207,9 +219,8 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
 
     const [
       total_maker_asset_balance_after,
-      total_taker_asset_balance_after
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -230,11 +241,6 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
       total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toString()
     ).to.equal(
       maker_amount.toString()
-    )
-    expect(
-      total_taker_asset_balance_after.sub(total_taker_asset_balance_before).toString()
-    ).to.equal(
-      taker_amount.toString()
     )
 
     // validate taker change
@@ -278,14 +284,19 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
       .callParams({ forward: { assetId: maker_asset, amount: maker_amount } })
       .call()
 
-
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -294,6 +305,13 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
     ] = await OrderTestUtils.getConventionalBalances(
       taker,
       [maker_asset, taker_asset]
+    )
+
+    const [
+      total_maker_asset_balance_before,
+    ] = await OrderTestUtils.getTotalBalances(
+      [maker_asset],
+      Orders
     )
 
     /** DEFINE PARAMETERS */
@@ -344,13 +362,20 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
     const tx = await taker.sendTransaction(finalRequest, { estimateTxDependencies: true })
     await tx.waitForResult()
 
+
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -359,6 +384,13 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
     ] = await OrderTestUtils.getConventionalBalances(
       taker,
       [maker_asset, taker_asset]
+    )
+
+    const [
+      total_maker_asset_balance_after,
+    ] = await OrderTestUtils.getTotalBalances(
+      [maker_asset],
+      Orders
     )
 
     // validate maker change
@@ -372,6 +404,14 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
     ).to.equal(
       taker_fill_amount.toString()
     )
+
+    // validate total balances
+    expect(
+      total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toString()
+    ).to.equal(
+      maker_fill_amount.toString()
+    )
+
 
     // validate taker change
     expect(
@@ -418,11 +458,17 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
 
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -435,9 +481,8 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
 
     const [
       total_maker_asset_balance_before,
-      total_taker_asset_balance_before
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
 
@@ -453,7 +498,7 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
       maker_receiver: ZeroBytes32
     })
 
-    const order1: OrderInput =  OrderTestUtils.getOrder({
+    const order1: OrderInput = OrderTestUtils.getOrder({
       maker_asset, // asset_out
       taker_asset: intermediate_asset, // asset_mid
       maker_amount,
@@ -462,7 +507,7 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
       maker_traits: OrderTestUtils.MAX_EXPIRY,
       maker_receiver: ZeroBytes32
     })
-    
+
     const taker_fill_amount = OrderTestUtils.getRandomAmount(1, taker_amount.toNumber()) // this is the actual amount_in
 
     const intermediate_fill_amount = OrderTestUtils.computeMakerFillAmount(taker_fill_amount, order0.maker_amount, order0.taker_amount)
@@ -486,7 +531,7 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
         ]
       ]
     ]
-    
+
     const deadline = OrderTestUtils.MAX_EXPIRY
 
     const request = await (await OrderTestUtils.callExactInScriptScope(path, deadline, taker, Orders.id.toB256()))
@@ -510,11 +555,17 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
 
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -527,12 +578,10 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
 
     const [
       total_maker_asset_balance_after,
-      total_taker_asset_balance_after
     ] = await OrderTestUtils.getTotalBalances(
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
-
     // validate maker change
     expect(
       maker_maker_asset_balance_before.sub(maker_maker_asset_balance_after).toString()
@@ -550,11 +599,6 @@ describe('Order fill via `fill_funded` through BatchSwapExactInScript', async ()
       total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toString()
     ).to.equal(
       maker_fill_amount.toString()
-    )
-    expect(
-      total_taker_asset_balance_after.sub(total_taker_asset_balance_before).toString()
-    ).to.equal(
-      taker_fill_amount.toString()
     )
 
     // validate taker change

--- a/test/fillFundedExactOut.test.ts
+++ b/test/fillFundedExactOut.test.ts
@@ -37,13 +37,20 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
       .call()
 
 
+
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -54,9 +61,17 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
       [maker_asset, taker_asset]
     )
 
+    const [
+      total_maker_asset_balance_before,
+    ] = await OrderTestUtils.getTotalBalances(
+      [maker_asset],
+      Orders
+    )
+
+
     /** DEFINE PARAMETERS */
 
-    const order: OrderInput =  OrderTestUtils.getOrder({
+    const order: OrderInput = OrderTestUtils.getOrder({
       maker_asset,
       taker_asset,
       maker_amount,
@@ -110,11 +125,17 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
 
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -123,6 +144,13 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
     ] = await OrderTestUtils.getConventionalBalances(
       taker,
       [maker_asset, taker_asset]
+    )
+
+    const [
+      total_maker_asset_balance_after,
+    ] = await OrderTestUtils.getTotalBalances(
+      [maker_asset],
+      Orders
     )
 
     // validate maker change 
@@ -152,6 +180,15 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
     ).to.equal(
       taker_fill_amount.toString()
     )
+
+    // validate total balances
+    expect(
+      total_maker_asset_balance_before.sub(total_maker_asset_balance_after).toNumber()
+    ).to.approximately(
+      maker_fill_amount.toNumber(),
+      makerRoundingError
+    )
+
 
     // these checks make sure that swap routes always execute (we always receive enough)
 
@@ -214,13 +251,20 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
 
     await OrderTestUtils.createMakerDeposits(maker, Orders, [maker_asset, intermediate_asset], [maker_amount.toNumber(), intermediate_amount.toNumber()])
 
+
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -231,9 +275,10 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
       [maker_asset, taker_asset]
     )
 
+
     /** DEFINE PARAMETERS */
 
-    const order0: OrderInput =  OrderTestUtils.getOrder({
+    const order0: OrderInput = OrderTestUtils.getOrder({
       maker_asset: intermediate_asset, // asset_mid
       taker_asset, // asset_in
       maker_amount: intermediate_amount,
@@ -244,7 +289,7 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
       maker_receiver: ZeroBytes32
     })
 
-    const order1: OrderInput =  OrderTestUtils.getOrder({
+    const order1: OrderInput = OrderTestUtils.getOrder({
       maker_asset, // asset_out
       taker_asset: intermediate_asset, // asset_mid
       maker_amount,
@@ -311,11 +356,17 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
 
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const [
@@ -325,6 +376,7 @@ describe('Order fill via `fill_funded` through BatchSwapExactOutScript', async (
       taker,
       [maker_asset, taker_asset]
     )
+
 
     // weh have to adjust the rounding error as it propagates to the intermediate swap
     const makerRoundingError = Math.ceil((maker_amount.toNumber() / intermediate_amount.toNumber())) * Math.ceil(intermediate_amount.toNumber() / taker_amount.toNumber())

--- a/test/makerActions.test.ts
+++ b/test/makerActions.test.ts
@@ -214,12 +214,19 @@ describe('Maker Actions', async () => {
 
     const [
       maker_maker_asset_balance_before,
-      maker_taker_asset_balance_before
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
     )
+
+    const [
+      maker_taker_asset_balance_before
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
+    )
+
 
     // will fill order delegate's signature
     await OrderTestUtils.getOrders(taker, OrderTestUtils.contractIdBits(Orders)).functions.fill(
@@ -231,14 +238,19 @@ describe('Maker Actions', async () => {
       .callParams({ forward: { assetId: taker_asset, amount: taker_fill_amount } })
       .call()
 
-
     const [
       maker_maker_asset_balance_after,
-      maker_taker_asset_balance_after
     ] = await OrderTestUtils.getMakerBalances(
       maker.address.toB256(),
-      [maker_asset, taker_asset],
+      [maker_asset],
       Orders
+    )
+
+    const [
+      maker_taker_asset_balance_after
+    ] = await OrderTestUtils.getConventionalBalances(
+      maker,
+      [taker_asset],
     )
 
     const maker_fill_amount = OrderTestUtils.computeMakerFillAmount(taker_fill_amount, order.maker_amount, order.taker_amount)
@@ -296,7 +308,7 @@ describe('Maker Actions', async () => {
   });
 
 
-  test('Maker can delegate signature for cancellation', async () => {
+  test('Maker can delegate cancellation', async () => {
 
     const launched = await launchTestNode({ walletsConfig: { count: 4 } });
 

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -8,7 +8,7 @@ import { addressInput, contractIdInput } from '../ts-scripts/utils';
 describe('Order Rotuer', async () => {
 
 
-  test('Cannot reenter', async () => {
+  test('Can match exactly', async () => {
     const launched = await launchTestNode({ walletsConfig: { count: 4 } });
 
     const {
@@ -70,21 +70,137 @@ describe('Order Rotuer', async () => {
 
     const signatureMatch = await maker1.signMessage(OrderTestUtils.packOrder(orderMatch, Orders))
 
-    try {
-      await OrderTestUtils.getRouter(taker, OrderTestUtils.contractIdBits(Router)).functions.fill_order(
-        order,
-        signatureRaw,
-        taker_fill_amount,
-        contractIdInput(Router.id),
-        OrderTestUtils.routerParams(orderMatch, signatureMatch)
-      )
-        .callParams({ forward: { assetId: taker_asset, amount: taker_fill_amount } })
-        .addContracts([Orders])
-        .call()
-        expect(true).to.equal(false, "was able to reenter")
-    } catch(e) {
-      
-    }
+    await OrderTestUtils.getRouter(taker, OrderTestUtils.contractIdBits(Router)).functions.fill_order(
+      order,
+      signatureRaw,
+      taker_fill_amount,
+      contractIdInput(Orders.id),
+      OrderTestUtils.routerParams(orderMatch, signatureMatch)
+    )
+      .callParams({ forward: { assetId: taker_asset, amount: taker_fill_amount } })
+      .addContracts([Orders])
+      .call()
+
+  });
+
+
+  test('Can match vs larger order with worse price', async () => {
+    const launched = await launchTestNode({ walletsConfig: { count: 4 } });
+
+    const {
+      wallets: [maker0, deployer, taker, maker1]
+    } = launched;
+
+    const { Orders, tokens, Router } = await OrderTestUtils.fixtureWithRouter(deployer)
+
+    const [maker_asset, taker_asset] = await OrderTestUtils.createTokens(deployer, OrderTestUtils.contractIdBits(tokens))
+
+    await OrderTestUtils.fundWallets(
+      [maker0, taker, maker1],
+      OrderTestUtils.contractIdBits(tokens),
+      [maker_asset, taker_asset, taker_asset],
+      [OrderTestUtils.DEFAULT_MINT_AMOUNT, OrderTestUtils.DEFAULT_MINT_AMOUNT, OrderTestUtils.DEFAULT_MINT_AMOUNT]
+    )
+
+
+    const maker_amount = OrderTestUtils.getRandomAmount()
+    const taker_amount = OrderTestUtils.getRandomAmount()
+
+    const taker_increment = OrderTestUtils.getRandomAmount(1, 1000)
+
+
+    // compute a larger order that has a worse prive by adding an adjusted increment
+    const maker_increment = OrderTestUtils.getRandomAmount(
+      1,
+      maker_amount.mul(taker_increment).div(taker_amount).toNumber()
+    )
+
+    const maker_amount_match = taker_amount.add(taker_increment)
+    const taker_amount_match = maker_amount.add(maker_increment)
+
+    await OrderTestUtils.getOrders(maker0, OrderTestUtils.contractIdBits(Orders))
+      .functions.deposit(maker_asset, addressInput(maker0.address))
+      .callParams({ forward: { assetId: maker_asset, amount: maker_amount } })
+      .call()
+
+    await OrderTestUtils.getOrders(maker1, OrderTestUtils.contractIdBits(Orders))
+      .functions.deposit(taker_asset, addressInput(maker1.address))
+      .callParams({ forward: { assetId: taker_asset, amount: maker_amount_match } })
+      .call()
+
+
+    const order: OrderInput = OrderTestUtils.getOrder({
+      maker_asset,
+      taker_asset,
+      maker_amount,
+      taker_amount,
+      maker: maker0.address.toB256(),
+      nonce: OrderTestUtils.getRandomAmount(1),
+      maker_traits: OrderTestUtils.MAX_EXPIRY,
+      maker_receiver: ZeroBytes32
+    })
+
+
+    const orderMatch: OrderInput = OrderTestUtils.getOrder({
+      maker_asset: taker_asset,
+      taker_asset: maker_asset,
+      maker_amount: maker_amount_match,
+      taker_amount: taker_amount_match,
+      maker: maker1.address.toB256(),
+      nonce: OrderTestUtils.getRandomAmount(1),
+      maker_traits: OrderTestUtils.MAX_EXPIRY,
+      maker_receiver: ZeroBytes32
+    })
+
+    const taker_fill_amount = taker_amount
+
+    const signatureRaw = await maker0.signMessage(OrderTestUtils.packOrder(order, Orders))
+
+
+    const signatureMatch = await maker1.signMessage(OrderTestUtils.packOrder(orderMatch, Orders))
+
+
+    const [
+      touter_balance_before,
+    ] = await OrderTestUtils.getConventionalBalances(
+      taker,
+      [taker_asset]
+    )
+
+    const maker_fill_amount = OrderTestUtils.computeMakerFillAmount(
+      taker_fill_amount,
+      order.maker_amount,
+      order.taker_amount,
+    )
+
+    const backwards_taker_filled = OrderTestUtils.computeMakerFillAmount(
+      maker_fill_amount,
+      orderMatch.maker_amount,
+      orderMatch.taker_amount
+    )
+
+    const expected_profit = backwards_taker_filled.sub(taker_fill_amount).toNumber()
+
+    await OrderTestUtils.getRouter(taker, OrderTestUtils.contractIdBits(Router)).functions.fill_order(
+      order,
+      signatureRaw,
+      taker_fill_amount,
+      contractIdInput(Orders.id),
+      OrderTestUtils.routerParams(orderMatch, signatureMatch)
+    )
+      .addContracts([Orders])
+      .call()
+
+    const [
+      touter_balance_after,
+    ] = await OrderTestUtils.getConventionalBalances(
+      taker,
+      [taker_asset]
+    )
+
+
+    const profit = touter_balance_after.sub(touter_balance_before).toNumber()
+    expect(profit).to.equal(expected_profit)
   });
 });
 


### PR DESCRIPTION
- loosen reentrancy_guard to allowed nested fill calls
- lock for reentrancy on `taker_asset`
- add order match test
- always transfer out to maker_receiver